### PR TITLE
Atom uses rel=alterante to identify links for the source

### DIFF
--- a/src/Parser/AtomParser.php
+++ b/src/Parser/AtomParser.php
@@ -19,6 +19,7 @@ use FastFeed\Exception\RuntimeException;
  */
 class AtomParser extends AbstractParser implements ParserInterface
 {
+    const  SOURCE_LINK_ATTR = 'alternate';
 
     /**
      * Retrieve a Items's array
@@ -87,7 +88,7 @@ class AtomParser extends AbstractParser implements ParserInterface
         $nodeList = $node->getElementsByTagName('link');
         if ($nodeList->length) {
             foreach ($nodeList as $nodeResult) {
-                if ($nodeResult->getAttribute('type') != 'text/html') {
+                if ($nodeResult->getAttribute('rel') != self::SOURCE_LINK_ATTR) {
                     continue;
                 }
                 $item->setSource($nodeResult->getAttribute('href'));

--- a/tests/Parser/AtomParserFirstElementTest.php
+++ b/tests/Parser/AtomParserFirstElementTest.php
@@ -112,7 +112,11 @@ class AtomFirstElementParserTest extends AbstractAtomParserTest
         $content = $this->getContent($fileName);
         $item = $this->getItem($content);
 
-        $expected = $this->getFistAttributeFromXpath($content, "*/ns:link[@type='text/html']", 'href');
+        $expected = $this->getFistAttributeFromXpath(
+            $content,
+            "*/ns:link[@rel='" . AtomParser::SOURCE_LINK_ATTR . "']",
+            'href'
+        );
 
         $this->assertEquals(
             $expected,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |

---

The Atom RFC in section [4.2.7.2](http://tools.ietf.org/html/rfc4287#section-4.2.7.2) specifies that the `link` element with the attribute `rel=alternate` should be used to point to the article itself.
The previous implementation was seeking for `<link>` elements that had `type=text/html` which caused the retrieval of links for comments:

``` bash
2) FastFeed\Tests\Parser\AtomFirstElementParserTest::testSource with data set #2 ('unawebmaslibre.blogspot.com.xml')
Fail asserting that first element of unawebmaslibre.blogspot.com.xml has source "http://unawebmaslibre.blogspot.com/2013/03/libreoffice-4-desde-ppa.html#comment-form"
```

This PR solves this.
