### PR TITLE
Move guzzle to make use of version 4 or 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,12 @@
         "desarrolla2/cache": ">=1.0.0",
         "fastfeed/url": ">=0.1.0",
         "ezyang/htmlpurifier": "4.6.*",
-        "guzzle/guzzle": "~3.7"
+        "guzzlehttp/guzzle": ">=4.0,<=6.0"
     },
     "autoload": {
         "psr-4": {
             "FastFeed\\": "src/",
             "FastFeed\\Tests\\": "tests/"
         }
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -12,7 +12,7 @@ namespace FastFeed;
 use FastFeed\Parser\AtomParser;
 use FastFeed\Parser\RSSParser;
 use FastFeed\Logger\Logger;
-use Guzzle\Http\Client;
+use GuzzleHttp\Client;
 
 /**
  * Factory

--- a/src/FastFeedInterface.php
+++ b/src/FastFeedInterface.php
@@ -10,7 +10,7 @@
 
 namespace FastFeed;
 
-use Guzzle\Http\ClientInterface;
+use GuzzleHttp\ClientInterface;
 use Psr\Log\LoggerInterface;
 use FastFeed\Parser\ParserInterface;
 use FastFeed\Processor\ProcessorInterface;

--- a/tests/AbstractFastFeedTest.php
+++ b/tests/AbstractFastFeedTest.php
@@ -10,6 +10,7 @@
 namespace FastFeed\Tests;
 
 use FastFeed\FastFeed;
+use GuzzleHttp\Client;
 
 /**
  * AbstractFeedManagerTest
@@ -33,9 +34,7 @@ abstract class AbstractFastFeedTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->guzzleMock = $this->getMockBuilder('Guzzle\Http\ClientInterface')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->guzzleMock = new Client();
 
         $this->loggerMock = $this->getMockBuilder('Psr\Log\LoggerInterface')
             ->disableOriginalConstructor()

--- a/tests/Cache/FastFeedTest.php
+++ b/tests/Cache/FastFeedTest.php
@@ -13,6 +13,8 @@ use FastFeed\Tests\AbstractFastFeedTest;
 use FastFeed\Cache\FastFeed;
 use FastFeed\Item;
 use Desarrolla2\Cache\CacheInterface;
+use GuzzleHttp\Subscriber\Mock;
+use GuzzleHttp\Message\Response;
 
 /**
  * FastFeedTest
@@ -70,30 +72,13 @@ class FastFeedTest extends AbstractFastFeedTest
             ->method('set')
             ->will($this->returnValue(true));
 
-        $responseMock = $this->getMockBuilder('Guzzle\Http\Message\Response')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mock = new Mock([
+            new Response(200, array()),         // Use response object
+            "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"  // Use a response string
+        ]);
 
-        $responseMock
-            ->expects($this->once())
-            ->method('isSuccessful')
-            ->will($this->returnValue(true));
-
-        $responseMock->expects($this->once())
-            ->method('getBody')
-            ->will($this->returnValue(array(new Item())));
-
-        $requestMock = $this->getMockBuilder('Guzzle\Http\Message\Request')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $requestMock->expects($this->once())
-            ->method('send')
-            ->will($this->returnValue($responseMock));
-
-        $this->guzzleMock->expects($this->once())
-            ->method('get')
-            ->will($this->returnValue($requestMock));
+        // Add the mock subscriber to the client.
+        $this->guzzleMock->getEmitter()->attach($mock);
 
         $this->fastFeed->fetch('desarrolla2');
     }

--- a/tests/FastFeedFetchTest.php
+++ b/tests/FastFeedFetchTest.php
@@ -10,6 +10,8 @@
 namespace FastFeed\Tests;
 
 use FastFeed\Parser\RSSParser;
+use GuzzleHttp\Subscriber\Mock;
+use GuzzleHttp\Message\Response;
 
 /**
  * FastFeedFetchTest
@@ -33,30 +35,13 @@ class FastFeedFetchTest extends AbstractFastFeedTest
      */
     public function testFetch($content)
     {
-        $responseMock = $this->getMockBuilder('Guzzle\Http\Message\Response')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mock = new Mock([
+            new Response(200, array()),         // Use response object
+            "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"  // Use a response string
+        ]);
 
-        $responseMock
-            ->expects($this->once())
-            ->method('isSuccessful')
-            ->will($this->returnValue(true));
-
-        $responseMock->expects($this->once())
-            ->method('getBody')
-            ->will($this->returnValue($content));
-
-        $requestMock = $this->getMockBuilder('Guzzle\Http\Message\Request')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $requestMock->expects($this->once())
-            ->method('send')
-            ->will($this->returnValue($responseMock));
-
-        $this->guzzleMock->expects($this->once())
-            ->method('get')
-            ->will($this->returnValue($requestMock));
+        // Add the mock subscriber to the client.
+        $this->guzzleMock->getEmitter()->attach($mock);
 
         $this->fastFeed->addFeed('desarrolla2', 'http://desarrolla2.com/feed/');
         $this->fastFeed->pushParser(new RSSParser());

--- a/tests/FastFeedLoggerTest.php
+++ b/tests/FastFeedLoggerTest.php
@@ -10,6 +10,9 @@
 namespace FastFeed\Tests;
 
 use FastFeed\Parser\RSSParser;
+use GuzzleHttp\Client;
+use GuzzleHttp\Subscriber\Mock;
+use GuzzleHttp\Message\Response;
 
 /**
  * FastFeedLoggerTest
@@ -18,30 +21,14 @@ class FastFeedLoggerTest extends AbstractFastFeedTest
 {
     public function testFetch()
     {
-        $responseMock = $this->getMockBuilder('Guzzle\Http\Message\Response')
-            ->disableOriginalConstructor()
-            ->getMock();
+        // Create a mock subscriber and queue two responses.
+        $mock = new Mock([
+            new Response(500, array()),         // Use response object
+            "HTTP/1.1 500 \r\nContent-Length: 0\r\n\r\n"  // Use a response string
+        ]);
 
-        $responseMock
-            ->expects($this->once())
-            ->method('isSuccessful')
-            ->will($this->returnValue(false));
-
-        $responseMock->expects($this->once())
-            ->method('getStatusCode')
-            ->will($this->returnValue(500));
-
-        $requestMock = $this->getMockBuilder('Guzzle\Http\Message\Request')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $requestMock->expects($this->once())
-            ->method('send')
-            ->will($this->returnValue($responseMock));
-
-        $this->guzzleMock->expects($this->once())
-            ->method('get')
-            ->will($this->returnValue($requestMock));
+        // Add the mock subscriber to the client.
+        $this->guzzleMock->getEmitter()->attach($mock);
 
         $this->loggerMock->expects($this->once())
             ->method('log')

--- a/tests/FastFeedSetterTest.php
+++ b/tests/FastFeedSetterTest.php
@@ -19,7 +19,7 @@ class FastFeedSetterTest extends AbstractFastFeedTest
 
     public function testSetGuzzle()
     {
-        $guzzleMock = $this->getMock('Guzzle\Http\ClientInterface');
+        $guzzleMock = $this->getMock('GuzzleHttp\ClientInterface');
         $this->assertNull($this->fastFeed->setHttpClient($guzzleMock));
     }
 


### PR DESCRIPTION
- Remove some of the testing of mocking Guzzle and use testing as documented http://guzzle.readthedocs.org/en/latest/testing.html

A few questions : 

Why do you need a caching? Doesn't the guzzle http cache works?

May be we need to make use of the asynchronus requests.

I am looking at two libraries http://guzzle.readthedocs.org/en/latest/quickstart.html#using-responses and https://github.com/amphp/artax

That brings me to another portion, may be a bridge is better.

So the users can switch between various implementations. 

I would like to work when I get sometime on it and send a PR .
