### PR TITLE
Switch to using `egeloen/ivory-http-adapter`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "issues": "https://github.com/fastfeed/fastfeed/issues"
     },
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.8",
         "psr/log": "~1.0",
         "desarrolla2/cache": ">=1.0.0",
         "fastfeed/url": ">=0.1.0",

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,15 @@
         "desarrolla2/cache": ">=1.0.0",
         "fastfeed/url": ">=0.1.0",
         "ezyang/htmlpurifier": "4.6.*",
-        "guzzle/guzzle": "~3.7"
+        "guzzle/guzzle": "~3.7",
+        "egeloen/http-adapter": "~0.7.0"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/egeloen/http.git"
+        }
+    ],
     "autoload": {
         "psr-4": {
             "FastFeed\\": "src/",

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,8 @@
         "fastfeed/url": ">=0.1.0",
         "ezyang/htmlpurifier": "4.6.*",
         "guzzle/guzzle": "~3.7",
-        "egeloen/http-adapter": "~0.7.0"
+        "egeloen/http-adapter": "~0"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/egeloen/http.git"
-        }
-    ],
     "autoload": {
         "psr-4": {
             "FastFeed\\": "src/",

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -13,7 +13,7 @@
 
 namespace FastFeed;
 
-use Guzzle\Http\Client;
+use Ivory\HttpAdapter\HttpAdapterFactory;
 
 use FastFeed\Logger\Logger;
 use FastFeed\Parser\AtomParser;
@@ -29,7 +29,7 @@ abstract class Factory
      */
     public static function create()
     {
-        $fastFeed = new FastFeed(new Client(), new Logger(false));
+        $fastFeed = new FastFeed(HttpAdapterFactory::create('guzzle'), new Logger(false));
         $fastFeed->pushParser(new RSSParser());
         $fastFeed->pushParser(new AtomParser());
 

--- a/src/FastFeed.php
+++ b/src/FastFeed.php
@@ -13,6 +13,11 @@
 
 namespace FastFeed;
 
+use Ivory\HttpAdapter\HttpAdapterInterface;
+use Ivory\HttpAdapter\Message\InternalRequest;
+use Ivory\HttpAdapter\Message\Request;
+use Ivory\HttpAdapter\MultiHttpAdapterException;
+
 use Guzzle\Http\ClientInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -65,9 +70,9 @@ class FastFeed implements FastFeedInterface
      * @param ClientInterface $guzzle
      * @param LoggerInterface $logger
      */
-    public function __construct(ClientInterface $guzzle, LoggerInterface $logger)
+    public function __construct(HttpAdapterInterface $http, LoggerInterface $logger)
     {
-        $this->http = $guzzle;
+        $this->http = $http;
         $this->logger = $logger;
     }
 

--- a/tests/AbstractFastFeedTest.php
+++ b/tests/AbstractFastFeedTest.php
@@ -33,7 +33,7 @@ abstract class AbstractFastFeedTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->guzzleMock = $this->getMockBuilder('Guzzle\Http\ClientInterface')
+        $this->httpMock = $this->getMockBuilder('Ivory\HttpAdapter\GuzzleHttpAdapter')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -41,6 +41,6 @@ abstract class AbstractFastFeedTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->fastFeed = new FastFeed($this->guzzleMock, $this->loggerMock);
+        $this->fastFeed = new FastFeed($this->httpMock, $this->loggerMock);
     }
 }

--- a/tests/Cache/FastFeedManagerExceptionTest.php
+++ b/tests/Cache/FastFeedManagerExceptionTest.php
@@ -21,7 +21,7 @@ class FastFeedManagerExceptionTest extends AbstractFastFeedTest
     {
         parent::setUp();
 
-        $this->fastFeed = new FastFeed($this->guzzleMock, $this->loggerMock);
+        $this->fastFeed = new FastFeed($this->httpMock, $this->loggerMock);
         $this->fastFeed->addFeed('desarrolla2', 'http://desarrolla2.com/feed/');
     }
 

--- a/tests/Cache/FastFeedTest.php
+++ b/tests/Cache/FastFeedTest.php
@@ -32,7 +32,7 @@ class FastFeedTest extends AbstractFastFeedTest
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->fastFeed = new FastFeed($this->guzzleMock, $this->loggerMock);
+        $this->fastFeed = new FastFeed($this->httpMock, $this->loggerMock);
         $this->fastFeed->setCache($this->cacheMock);
         $this->fastFeed->addFeed('desarrolla2', 'http://desarrolla2.com/feed/');
     }
@@ -90,7 +90,7 @@ class FastFeedTest extends AbstractFastFeedTest
             ->method('send')
             ->will($this->returnValue($responseMock));
 
-        $this->guzzleMock->expects($this->once())
+        $this->httpMock->expects($this->once())
             ->method('get')
             ->will($this->returnValue($requestMock));
 

--- a/tests/FastFeedFetchTest.php
+++ b/tests/FastFeedFetchTest.php
@@ -53,7 +53,7 @@ class FastFeedFetchTest extends AbstractFastFeedTest
             ->method('send')
             ->will($this->returnValue($responseMock));
 
-        $this->guzzleMock->expects($this->once())
+        $this->httpMock->expects($this->once())
             ->method('get')
             ->will($this->returnValue($requestMock));
 

--- a/tests/FastFeedLoggerTest.php
+++ b/tests/FastFeedLoggerTest.php
@@ -39,7 +39,7 @@ class FastFeedLoggerTest extends AbstractFastFeedTest
             ->method('send')
             ->will($this->returnValue($responseMock));
 
-        $this->guzzleMock->expects($this->once())
+        $this->httpMock->expects($this->once())
             ->method('get')
             ->will($this->returnValue($requestMock));
 


### PR DESCRIPTION
By default, it uses `Guzzle` like it was before the change. I had
to define a custom VCS for now until https://github.com/phly/http/pull/44
is merged.

Closes #11.